### PR TITLE
add both qiskit-based and non-qiskit-based circuit equivalence checks (issue #12)

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,7 +4,7 @@ from qiskit.quantum_info import Statevector, Operator
 
 def assert_no_measurements(circuit: QuantumCircuit) -> QuantumCircuit:
         """
-        helper: remove measurements from quantum circuit
+        helper: checks for measurements in quantum circuit
 
         args:
             circuit: QuantumCircuit


### PR DESCRIPTION
tested locally with a couple of circuits, from a circuit generator function that will be pr'd later

5 qubit cliffordt circuit, before and after wisq opt:
<img width="2412" height="595" alt="image" src="https://github.com/user-attachments/assets/5017c3b6-7e8e-4cf0-a283-d42e776ce26b" />

and with 17 qubit circuit present in the example circuits folder
<img width="2424" height="133" alt="image" src="https://github.com/user-attachments/assets/2c0b0747-92a1-4b71-b673-a584214c7e53" />

and after chaning a single gate in the file...
<img width="2411" height="121" alt="image" src="https://github.com/user-attachments/assets/78e6a7ec-abfa-4023-bdb4-c0349aa885f0" />